### PR TITLE
func tmplMod edit

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -284,9 +284,9 @@ func tmplDiv(args ...interface{}) interface{} {
 	}
 }
 
-func tmplMod(args ...interface{}) interface{} {
+func tmplMod(args ...interface{}) float64 {
 	if len(args) != 2 {
-		return 0
+		return math.NaN()
 	}
 
 	return math.Mod(ToFloat64(args[0]), ToFloat64(args[1]))


### PR DESCRIPTION
if there are more or less than two arguments given, it should not return 0 because 0 is valid answer for modulo. It's better to return NaN and stay in type  float64 as return.