### PR TITLE
templates: toInt, toInt64, toFloat

### DIFF
--- a/common/templates/general.go
+++ b/common/templates/general.go
@@ -778,6 +778,10 @@ func tmplToInt(from interface{}) int {
 		return int(parsed)
 	case time.Duration:
 		return int(t)
+	case time.Month:
+		return int(t)
+	case time.Weekday:
+		return int(t)
 	default:
 		return 0
 	}
@@ -805,6 +809,10 @@ func ToInt64(from interface{}) int64 {
 		parsed, _ := strconv.ParseInt(t, 10, 64)
 		return parsed
 	case time.Duration:
+		return int64(t)
+	case time.Month:
+		return int64(t)
+	case time.Weekday:
 		return int64(t)
 	default:
 		return 0
@@ -864,6 +872,10 @@ func ToFloat64(from interface{}) float64 {
 		parsed, _ := strconv.ParseFloat(t, 64)
 		return parsed
 	case time.Duration:
+		return float64(t)
+	case time.Month:
+		return float64(t)
+	case time.Weekday:
 		return float64(t)
 	default:
 		return 0


### PR DESCRIPTION
above functions should handle time.Month and time.Weekday as well and not return 0