### PR TITLE
templates: .BotUser to context data

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -228,6 +228,7 @@ func (c *Context) setupBaseData() {
 	}
 
 	if c.MS != nil {
+		c.Data["BotUser"] = common.BotUser
 		c.Data["Member"] = c.MS.DgoMember()
 		c.Data["User"] = &c.MS.User
 		c.Data["user"] = c.Data["User"]


### PR DESCRIPTION
Makes it easier to get YAGPDB's ID or any other reference to bot user in custom commands.